### PR TITLE
Bump org.apache.commons:commons-compress from 1.21 to 1.26.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
 <dependency>
     <groupId>org.apache.commons</groupId>
     <artifactId>commons-compress</artifactId>
-    <version>1.21</version>
+    <version>1.26.0</version>
 </dependency>
 <!-- https://mvnrepository.com/artifact/org.apache.poi/poi-ooxml -->
 <dependency>


### PR DESCRIPTION
Bumps org.apache.commons:commons-compress from 1.21 to 1.26.0.

---
updated-dependencies:
- dependency-name: org.apache.commons:commons-compress dependency-type: direct:production ...